### PR TITLE
Handle errors and timeouts in Lambda function

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 AWS_LAMBDA_FUNCTION_NAME=aws-codedeploy-hook-LifecycleEvent
 AWS_LAMBDA_FUNCTION_VERSION=local
 AWS_REGION=ap-southeast-4
+ENVIRONMENT=local

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.10.6",
+    "dotenv": "16.3.1",
     "skuba": "7.3.1"
   },
   "packageManager": "pnpm@8.14.0",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -2,6 +2,7 @@
   "name": "@seek/aws-codedeploy-infra",
   "license": "MIT",
   "dependencies": {
+    "@seek/logger": "^6.2.0",
     "@types/aws-lambda": "^8.10.130",
     "aws-cdk-lib": "^2.115.0",
     "constructs": "^10.3.0",
@@ -13,6 +14,7 @@
     "@aws-sdk/client-codedeploy": "3.485.0",
     "@aws-sdk/client-lambda": "3.485.0",
     "aws-sdk-client-mock": "3.0.1",
-    "aws-sdk-client-mock-jest": "3.0.1"
+    "aws-sdk-client-mock-jest": "3.0.1",
+    "pino-pretty": "10.3.1"
   }
 }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -14,7 +14,7 @@
     "@aws-sdk/client-codedeploy": "3.485.0",
     "@aws-sdk/client-lambda": "3.485.0",
     "aws-sdk-client-mock": "3.0.1",
-    "aws-sdk-client-mock-jest": "3.0.1",
+    "aws-sdk-client-mock-jest": "3.1.0-beta.0",
     "pino-pretty": "10.3.1"
   }
 }

--- a/packages/infra/src/handlers/config.test.ts
+++ b/packages/infra/src/handlers/config.test.ts
@@ -1,20 +1,44 @@
+import dotenv from 'dotenv';
+
 describe('config', () => {
-  it('throws an error if all environment variables are not set', () => {
-    process.env = {};
+  it('throws an error if all environment variables are not set', () =>
+    // @ts-expect-error - missing from `@types/jest`
+    jest.isolateModulesAsync(async () => {
+      process.env = {};
 
-    expect(() => require('./config')).toThrowErrorMatchingInlineSnapshot(
-      `"The following environment variables are not set: AWS_DEFAULT_REGION, AWS_LAMBDA_FUNCTION_NAME, AWS_REGION, AWS_LAMBDA_FUNCTION_VERSION"`,
-    );
-  });
+      await expect(
+        import('./config'),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"The following environment variables are not set: AWS_DEFAULT_REGION, AWS_LAMBDA_FUNCTION_NAME, AWS_REGION, AWS_LAMBDA_FUNCTION_VERSION"`,
+      );
+    }));
 
-  it('throws an error if some environment variables are not set', () => {
-    process.env = {
-      AWS_LAMBDA_FUNCTION_NAME: 'aws-codedeploy-hook-LifecycleEvent',
-      AWS_LAMBDA_FUNCTION_VERSION: 'local',
-    };
+  it('throws an error if some environment variables are not set', () =>
+    // @ts-expect-error - missing from `@types/jest`
+    jest.isolateModulesAsync(async () => {
+      process.env = {
+        AWS_LAMBDA_FUNCTION_NAME: 'aws-codedeploy-hook-LifecycleEvent',
+        AWS_LAMBDA_FUNCTION_VERSION: 'local',
+      };
 
-    expect(() => require('./config')).toThrowErrorMatchingInlineSnapshot(
-      `"The following environment variables are not set: AWS_DEFAULT_REGION, AWS_REGION"`,
-    );
-  });
+      await expect(
+        import('./config'),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"The following environment variables are not set: AWS_DEFAULT_REGION, AWS_REGION"`,
+      );
+    }));
+
+  it.each(['local', 'production', 'test'])(
+    'initialises in %s environment',
+    (environment) =>
+      // @ts-expect-error - missing from `@types/jest`
+      jest.isolateModulesAsync(async () => {
+        dotenv.config();
+        process.env.ENVIRONMENT = environment;
+
+        await expect(import('./config')).resolves.toMatchObject({
+          config: { environment },
+        });
+      }),
+  );
 });

--- a/packages/infra/src/handlers/config.test.ts
+++ b/packages/infra/src/handlers/config.test.ts
@@ -1,44 +1,44 @@
 import dotenv from 'dotenv';
 
 describe('config', () => {
-  it('throws an error if all environment variables are not set', () =>
-    // @ts-expect-error - missing from `@types/jest`
-    jest.isolateModulesAsync(async () => {
-      process.env = {};
+  it('throws an error if all environment variables are not set', () => {
+    process.env = {};
 
+    return jest.isolateModulesAsync(async () => {
       await expect(
         import('./config'),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"The following environment variables are not set: AWS_DEFAULT_REGION, AWS_LAMBDA_FUNCTION_NAME, AWS_REGION, AWS_LAMBDA_FUNCTION_VERSION"`,
       );
-    }));
+    });
+  });
 
-  it('throws an error if some environment variables are not set', () =>
-    // @ts-expect-error - missing from `@types/jest`
-    jest.isolateModulesAsync(async () => {
-      process.env = {
-        AWS_LAMBDA_FUNCTION_NAME: 'aws-codedeploy-hook-LifecycleEvent',
-        AWS_LAMBDA_FUNCTION_VERSION: 'local',
-      };
+  it('throws an error if some environment variables are not set', () => {
+    process.env = {
+      AWS_LAMBDA_FUNCTION_NAME: 'aws-codedeploy-hook-LifecycleEvent',
+      AWS_LAMBDA_FUNCTION_VERSION: 'local',
+    };
 
+    return jest.isolateModulesAsync(async () => {
       await expect(
         import('./config'),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"The following environment variables are not set: AWS_DEFAULT_REGION, AWS_REGION"`,
       );
-    }));
+    });
+  });
 
   it.each(['local', 'production', 'test'])(
     'initialises in %s environment',
-    (environment) =>
-      // @ts-expect-error - missing from `@types/jest`
-      jest.isolateModulesAsync(async () => {
-        dotenv.config();
-        process.env.ENVIRONMENT = environment;
+    (environment) => {
+      dotenv.config();
+      process.env.ENVIRONMENT = environment;
 
+      return jest.isolateModulesAsync(async () => {
         await expect(import('./config')).resolves.toMatchObject({
           config: { environment },
         });
-      }),
+      });
+    },
   );
 });

--- a/packages/infra/src/handlers/config.test.ts
+++ b/packages/infra/src/handlers/config.test.ts
@@ -1,6 +1,31 @@
 import dotenv from 'dotenv';
 
 describe('config', () => {
+  it.each(['local', 'production', 'test'])(
+    'initialises in %s environment',
+    (environment) => {
+      dotenv.config();
+      process.env.ENVIRONMENT = environment;
+
+      return jest.isolateModulesAsync(async () => {
+        await expect(import('./config')).resolves.toMatchObject({
+          config: { environment },
+        });
+      });
+    },
+  );
+
+  it('defaults to production environment', () => {
+    dotenv.config();
+    delete process.env.ENVIRONMENT;
+
+    return jest.isolateModulesAsync(async () => {
+      await expect(import('./config')).resolves.toMatchObject({
+        config: { environment: 'production' },
+      });
+    });
+  });
+
   it('throws an error if all environment variables are not set', () => {
     process.env = {};
 
@@ -27,18 +52,4 @@ describe('config', () => {
       );
     });
   });
-
-  it.each(['local', 'production', 'test'])(
-    'initialises in %s environment',
-    (environment) => {
-      dotenv.config();
-      process.env.ENVIRONMENT = environment;
-
-      return jest.isolateModulesAsync(async () => {
-        await expect(import('./config')).resolves.toMatchObject({
-          config: { environment },
-        });
-      });
-    },
-  );
 });

--- a/packages/infra/src/handlers/config.ts
+++ b/packages/infra/src/handlers/config.ts
@@ -25,8 +25,14 @@ if (!AWS_LAMBDA_FUNCTION_NAME || !AWS_LAMBDA_FUNCTION_VERSION || !region) {
 // TODO: should we include build number / commit hash / npm package version?
 const userAgent = `aws-codedeploy-hooks/${AWS_LAMBDA_FUNCTION_VERSION}`;
 
+const environment =
+  process.env.ENVIRONMENT === 'local' || process.env.ENVIRONMENT === 'test'
+    ? process.env.ENVIRONMENT
+    : 'production';
+
 export const config = {
   functionName: AWS_LAMBDA_FUNCTION_NAME,
+  environment,
   region,
   userAgent,
-} satisfies Record<string, string>;
+} as const satisfies Record<string, string>;

--- a/packages/infra/src/handlers/framework/context.test.ts
+++ b/packages/infra/src/handlers/framework/context.test.ts
@@ -1,4 +1,12 @@
-import { getAbortSignal, getContext, getRequestId, storage } from './context';
+import { setTimeout } from 'timers/promises';
+
+import {
+  getAbortSignal,
+  getContext,
+  getRequestId,
+  storage,
+  withTimeout,
+} from './context';
 
 const context = {
   abortSignal: new AbortController().signal,
@@ -8,21 +16,53 @@ const context = {
 describe('getAbortSignal', () => {
   it('returns the current abort signal where available', () =>
     storage.run(context, () =>
-      expect(getAbortSignal()).toEqual(context.abortSignal),
+      expect(getAbortSignal()).toStrictEqual(context.abortSignal),
     ));
 });
 
 describe('getContext', () => {
   it('returns the current context where available', () =>
-    storage.run(context, () => expect(getContext()).toEqual(context)));
+    storage.run(context, () => expect(getContext()).toStrictEqual(context)));
 
   it('returns an empty object if there is no context', () =>
-    expect(getContext()).toEqual({}));
+    expect(getContext()).toStrictEqual({}));
 });
 
 describe('getRequestId', () => {
   it('returns the current request ID where available', () =>
     storage.run(context, () =>
-      expect(getRequestId()).toEqual(context.requestId),
+      expect(getRequestId()).toStrictEqual(context.requestId),
     ));
+});
+
+describe('withTimeout', () => {
+  it('returns task result on happy path', async () => {
+    const result = 'mock-result';
+
+    const task = jest.fn().mockResolvedValue(result);
+
+    await expect(withTimeout(task, 100)).resolves.toStrictEqual(result);
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it('enforces a timeout', async () => {
+    const task = jest
+      .fn()
+      .mockImplementation(() =>
+        setTimeout(200, undefined, { signal: getAbortSignal() }),
+      );
+
+    await expect(
+      withTimeout(task, 100),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Task timed out after 100ms: mockConstructor"`,
+    );
+
+    expect(task).toHaveBeenCalledTimes(1);
+
+    await expect(
+      task.mock.results[0]!.value,
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"The operation was aborted"`);
+  });
 });

--- a/packages/infra/src/handlers/framework/context.test.ts
+++ b/packages/infra/src/handlers/framework/context.test.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from 'timers/promises';
+import { inspect } from 'util';
 
 import {
   getAbortSignal,
@@ -46,6 +47,20 @@ describe('withTimeout', () => {
     expect(task).toHaveBeenCalledTimes(1);
   });
 
+  it('returns task result on happy path with a dormant parent signal', async () => {
+    const result = 'mock-result';
+
+    const task = jest.fn().mockResolvedValue(result);
+
+    await expect(
+      storage.run({ abortSignal: new AbortController().signal }, () =>
+        withTimeout(task, 100),
+      ),
+    ).resolves.toStrictEqual(result);
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
   it('enforces a timeout', async () => {
     const task = jest
       .fn()
@@ -55,14 +70,44 @@ describe('withTimeout', () => {
 
     await expect(
       withTimeout(task, 100),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Task timed out after 100ms: mockConstructor"`,
-    );
-
-    expect(task).toHaveBeenCalledTimes(1);
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"The operation was aborted"`);
 
     await expect(
-      task.mock.results[0]!.value,
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"The operation was aborted"`);
+      task.mock.results[0]!.value.catch((err: unknown) =>
+        inspect(err)
+          .replaceAll(/\s+at [^\r\n]+/g, '\n')
+          .replaceAll(/[\r\n]+/g, '\n'),
+      ),
+    ).resolves.toMatchInlineSnapshot(`
+      "AbortError: The operation was aborted
+        code: 'ABORT_ERR',
+        [cause]: DOMException [TimeoutError]: The operation was aborted due to timeout
+      }"
+    `);
   });
+
+  const TEST_TIMEOUT_MS = 5_000;
+  it(
+    'propagates a parent signal abortion',
+    async () => {
+      const task = jest
+        .fn()
+        .mockImplementation(() =>
+          setTimeout(200, undefined, { signal: getAbortSignal() }),
+        );
+
+      // This will time out
+      const abortSignal = AbortSignal.timeout(100);
+
+      await expect(
+        storage.run({ abortSignal }, () =>
+          // This won't time out
+          withTimeout(task, TEST_TIMEOUT_MS + 1_000),
+        ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"The operation was aborted"`,
+      );
+    },
+    TEST_TIMEOUT_MS,
+  );
 });

--- a/packages/infra/src/handlers/framework/context.ts
+++ b/packages/infra/src/handlers/framework/context.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'async_hooks';
+import { setTimeout } from 'timers/promises';
 
 type Context = {
   abortSignal?: AbortSignal;
@@ -12,3 +13,32 @@ export const getContext = (): Context => storage.getStore() ?? {};
 export const getAbortSignal = () => storage.getStore()?.abortSignal;
 
 export const getRequestId = () => storage.getStore()?.requestId;
+
+export const withTimeout = async <T>(
+  task: () => Promise<T>,
+  timeoutMs: number,
+): Promise<T> => {
+  const cancelTask = new AbortController();
+  const cancelTimeout = new AbortController();
+
+  const runTask = async (): Promise<T> => {
+    try {
+      return await storage.run(
+        { ...getContext(), abortSignal: cancelTask.signal },
+        task,
+      );
+    } finally {
+      cancelTimeout.abort();
+    }
+  };
+
+  const runTimeout = async (): Promise<never> => {
+    await setTimeout(timeoutMs, undefined, { signal: cancelTimeout.signal });
+
+    cancelTask.abort();
+
+    throw new Error(`Task timed out after ${timeoutMs}ms: ${task.name}`);
+  };
+
+  return Promise.race([runTask(), runTimeout()]);
+};

--- a/packages/infra/src/handlers/framework/logging.test.ts
+++ b/packages/infra/src/handlers/framework/logging.test.ts
@@ -1,14 +1,14 @@
 describe('logger', () => {
   it.each(['local', 'production', 'test'])(
     'initialises in %s environment',
-    (environment) =>
-      // @ts-expect-error - missing from `@types/jest`
-      jest.isolateModulesAsync(async () => {
-        process.env.ENVIRONMENT = environment;
+    (environment) => {
+      process.env.ENVIRONMENT = environment;
 
+      return jest.isolateModulesAsync(async () => {
         await expect(import('./logging')).resolves.toMatchObject({
           logger: expect.any(Object),
         });
-      }),
+      });
+    },
   );
 });

--- a/packages/infra/src/handlers/framework/logging.test.ts
+++ b/packages/infra/src/handlers/framework/logging.test.ts
@@ -1,0 +1,14 @@
+describe('logger', () => {
+  it.each(['local', 'production', 'test'])(
+    'initialises in %s environment',
+    (environment) =>
+      // @ts-expect-error - missing from `@types/jest`
+      jest.isolateModulesAsync(async () => {
+        process.env.ENVIRONMENT = environment;
+
+        await expect(import('./logging')).resolves.toMatchObject({
+          logger: expect.any(Object),
+        });
+      }),
+  );
+});

--- a/packages/infra/src/handlers/framework/logging.ts
+++ b/packages/infra/src/handlers/framework/logging.ts
@@ -1,0 +1,24 @@
+import createLogger from '@seek/logger';
+
+import { config } from '../config';
+
+import { getRequestId } from './context';
+
+export const testLogs: unknown[] = [];
+
+const testDestination = {
+  write: (data: string) => testLogs.push(JSON.parse(data)),
+};
+
+export const logger = createLogger(
+  {
+    base: null,
+
+    mixin: () => ({ awsRequestId: getRequestId() }),
+
+    transport:
+      config.environment === 'local' ? { target: 'pino-pretty' } : undefined,
+  },
+
+  config.environment === 'test' ? testDestination : undefined,
+);

--- a/packages/infra/src/handlers/index.test.ts
+++ b/packages/infra/src/handlers/index.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@aws-sdk/client-codedeploy';
 import { mockClient } from 'aws-sdk-client-mock';
 
+import { testLogs } from './framework/logging';
 import { processEvent } from './process/process';
 
 import { handler } from '.';
@@ -20,6 +21,7 @@ const processEventMock = jest.mocked(processEvent);
 afterEach(() => {
   codeDeploy.reset();
   processEventMock.mockReset();
+  testLogs.length = 0;
 });
 
 describe('handler', () => {
@@ -36,24 +38,155 @@ describe('handler', () => {
     getRemainingTimeInMillis: () => 300_000,
   };
 
-  it('reports the event status back to CodeDeploy', async () => {
-    codeDeploy
-      .on(PutLifecycleEventHookExecutionStatusCommand, {
-        deploymentId: event.DeploymentId,
-        lifecycleEventHookExecutionId: event.LifecycleEventHookExecutionId,
-        status: LifecycleEventStatus.SUCCEEDED,
-      })
-      .resolves({});
-
+  it('reports a success back to CodeDeploy', async () => {
     processEventMock.mockResolvedValue(undefined);
+
+    codeDeploy.on(PutLifecycleEventHookExecutionStatusCommand).resolves({});
 
     await expect(handler(event, context)).resolves.toBeUndefined();
 
     expect(processEventMock).toHaveBeenCalledTimes(1);
 
-    expect(codeDeploy).toHaveReceivedCommandTimes(
-      PutLifecycleEventHookExecutionStatusCommand,
+    expect(codeDeploy).toHaveReceivedNthCommandWith(
       1,
+      PutLifecycleEventHookExecutionStatusCommand,
+      {
+        deploymentId: event.DeploymentId,
+        lifecycleEventHookExecutionId: event.LifecycleEventHookExecutionId,
+        status: LifecycleEventStatus.SUCCEEDED,
+      },
     );
+
+    expect(testLogs).toStrictEqual([
+      {
+        awsRequestId: context.awsRequestId,
+        level: 30,
+        msg: 'Reported lifecycle event status',
+        status: LifecycleEventStatus.SUCCEEDED,
+        timestamp: expect.any(String),
+      },
+    ]);
+  });
+
+  it('reports a failure back to CodeDeploy', async () => {
+    const err = new Error('mock-error');
+
+    processEventMock.mockRejectedValue(err);
+
+    codeDeploy.on(PutLifecycleEventHookExecutionStatusCommand).resolves({});
+
+    await expect(handler(event, context)).resolves.toBeUndefined();
+
+    expect(processEventMock).toHaveBeenCalledTimes(1);
+
+    expect(codeDeploy).toHaveReceivedNthCommandWith(
+      1,
+      PutLifecycleEventHookExecutionStatusCommand,
+      {
+        deploymentId: event.DeploymentId,
+        lifecycleEventHookExecutionId: event.LifecycleEventHookExecutionId,
+        status: LifecycleEventStatus.FAILED,
+      },
+    );
+
+    expect(testLogs).toStrictEqual([
+      {
+        awsRequestId: context.awsRequestId,
+        err: expect.objectContaining({ message: err.message }),
+        level: 50,
+        msg: 'Failed to process lifecycle event',
+        timestamp: expect.any(String),
+      },
+      {
+        awsRequestId: context.awsRequestId,
+        level: 30,
+        msg: 'Reported lifecycle event status',
+        status: LifecycleEventStatus.FAILED,
+        timestamp: expect.any(String),
+      },
+    ]);
+  });
+
+  it('throws a failure to report a success', async () => {
+    const err = new Error('mock-error');
+
+    processEventMock.mockResolvedValue(undefined);
+
+    codeDeploy.on(PutLifecycleEventHookExecutionStatusCommand).rejects(err);
+
+    await expect(
+      handler(event, context),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Failed to report lifecycle event status"`,
+    );
+
+    expect(processEventMock).toHaveBeenCalledTimes(1);
+
+    expect(codeDeploy).toHaveReceivedNthCommandWith(
+      1,
+      PutLifecycleEventHookExecutionStatusCommand,
+      {
+        deploymentId: event.DeploymentId,
+        lifecycleEventHookExecutionId: event.LifecycleEventHookExecutionId,
+        status: LifecycleEventStatus.SUCCEEDED,
+      },
+    );
+
+    expect(testLogs).toStrictEqual([
+      {
+        awsRequestId: context.awsRequestId,
+        err: expect.objectContaining({ message: err.message }),
+        level: 50,
+        msg: 'Failed to report lifecycle event status',
+        status: LifecycleEventStatus.SUCCEEDED,
+        timestamp: expect.any(String),
+      },
+    ]);
+  });
+  it('throws a failure to report a failure', async () => {
+    const processError = new Error('mock-process-error');
+    const reportError = new Error('mock-report-error');
+
+    codeDeploy
+      .on(PutLifecycleEventHookExecutionStatusCommand)
+      .rejects(reportError);
+
+    processEventMock.mockRejectedValue(processError);
+
+    await expect(
+      handler(event, context),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Failed to report lifecycle event status"`,
+    );
+
+    expect(processEventMock).toHaveBeenCalledTimes(1);
+
+    expect(codeDeploy).toHaveReceivedNthCommandWith(
+      1,
+      PutLifecycleEventHookExecutionStatusCommand,
+      {
+        deploymentId: event.DeploymentId,
+        lifecycleEventHookExecutionId: event.LifecycleEventHookExecutionId,
+        status: LifecycleEventStatus.FAILED,
+      },
+    );
+
+    expect(testLogs).toStrictEqual([
+      {
+        awsRequestId: context.awsRequestId,
+        err: expect.objectContaining({ message: processError.message }),
+        level: 50,
+        msg: 'Failed to process lifecycle event',
+        timestamp: expect.any(String),
+      },
+      {
+        awsRequestId: context.awsRequestId,
+        err: expect.objectContaining({ message: reportError.message }),
+        level: 50,
+        msg: 'Failed to report lifecycle event status',
+        status: LifecycleEventStatus.FAILED,
+        timestamp: expect.any(String),
+      },
+    ]);
   });
 });

--- a/packages/infra/src/handlers/index.test.ts
+++ b/packages/infra/src/handlers/index.test.ts
@@ -107,7 +107,7 @@ describe('handler', () => {
     ]);
   });
 
-  it('throws a failure to report a success', async () => {
+  it('throws on failure to report a success', async () => {
     const err = new Error('mock-error');
 
     processEventMock.mockResolvedValue(undefined);
@@ -143,7 +143,8 @@ describe('handler', () => {
       },
     ]);
   });
-  it('throws a failure to report a failure', async () => {
+
+  it('throws on failure to report a failure', async () => {
     const processError = new Error('mock-process-error');
     const reportError = new Error('mock-report-error');
 

--- a/packages/infra/src/handlers/index.ts
+++ b/packages/infra/src/handlers/index.ts
@@ -1,18 +1,38 @@
 import { LifecycleEventStatus } from '@aws-sdk/client-codedeploy';
 import type { Context } from 'aws-lambda';
 
+import { storage, withTimeout } from './framework/context';
+import { logger } from './framework/logging';
 import { processEvent } from './process/process';
 import { reportEventStatus } from './report';
 import type { CodeDeployLifecycleHookEvent } from './types';
 
-export const handler = async (
+export const handler = (
   event: CodeDeployLifecycleHookEvent,
-  _context: Pick<Context, 'awsRequestId' | 'getRemainingTimeInMillis'>,
-): Promise<void> => {
-  // TODO: handle errors
-  await processEvent(event);
+  context: Pick<Context, 'awsRequestId' | 'getRemainingTimeInMillis'>,
+): Promise<void> =>
+  storage.run({ requestId: context.awsRequestId }, async () => {
+    // Reserve a generous 30 seconds to report the status back to CodeDeploy.
+    const timeoutMs = context.getRemainingTimeInMillis() - 30_000;
 
-  await reportEventStatus(event, LifecycleEventStatus.SUCCEEDED);
+    let status: LifecycleEventStatus = LifecycleEventStatus.FAILED;
+    try {
+      await withTimeout(() => processEvent(event), timeoutMs);
 
-  return;
-};
+      status = LifecycleEventStatus.SUCCEEDED;
+    } catch (err) {
+      logger.error({ err }, 'Failed to process lifecycle event');
+    }
+
+    try {
+      await reportEventStatus(event, status);
+
+      logger.info({ status }, 'Reported lifecycle event status');
+    } catch (err) {
+      const message = 'Failed to report lifecycle event status';
+
+      logger.error({ err, status }, message);
+
+      throw new Error(message);
+    }
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
       aws-sdk-client-mock-jest:
-        specifier: 3.0.1
-        version: 3.0.1(aws-sdk-client-mock@3.0.1)
+        specifier: 3.1.0-beta.0
+        version: 3.1.0-beta.0(aws-sdk-client-mock@3.0.1)
       pino-pretty:
         specifier: 10.3.1
         version: 10.3.1
@@ -1490,13 +1490,6 @@ packages:
       jest-mock: 29.7.0
     dev: true
 
-  /@jest/expect-utils@28.1.3:
-    resolution: {integrity: sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      jest-get-type: 28.0.2
-    dev: true
-
   /@jest/expect-utils@29.7.0:
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1575,13 +1568,6 @@ packages:
       - supports-color
     dev: true
 
-  /@jest/schemas@28.1.3:
-    resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.24.51
-    dev: true
-
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1639,18 +1625,6 @@ packages:
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@jest/types@28.1.3:
-    resolution: {integrity: sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@jest/schemas': 28.1.3
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.10.6
-      '@types/yargs': 17.0.32
-      chalk: 4.1.2
     dev: true
 
   /@jest/types@29.6.3:
@@ -2047,10 +2021,6 @@ packages:
       semantic-release: 21.1.2(typescript@5.2.2)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@sinclair/typebox@0.24.51:
-    resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
     dev: true
 
   /@sinclair/typebox@0.27.8:
@@ -2596,13 +2566,6 @@ packages:
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
-    dev: true
-
-  /@types/jest@28.1.8:
-    resolution: {integrity: sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==}
-    dependencies:
-      expect: 28.1.3
-      pretty-format: 28.1.3
     dev: true
 
   /@types/jest@29.5.11:
@@ -3175,13 +3138,13 @@ packages:
       - table
       - yaml
 
-  /aws-sdk-client-mock-jest@3.0.1(aws-sdk-client-mock@3.0.1):
-    resolution: {integrity: sha512-eT0i+XkvitMt7ml2LVUayVd6oiFO7SqLQBEbRId094fs2qlWlL+Png0WuOFVCIcTZgjoK5v81UnKSLwFbbpWqA==}
+  /aws-sdk-client-mock-jest@3.1.0-beta.0(aws-sdk-client-mock@3.0.1):
+    resolution: {integrity: sha512-5t8GrnsqdqPjpjKM+dacMhG1ifq6TZavHH3mHchh1uICqrxke42mcF12e54z6ESvS83ItYA5gwjAuzccRvZ/Bw==}
     peerDependencies:
-      aws-sdk-client-mock: 3.0.1
+      aws-sdk-client-mock: 3.1.0-beta.0
     dependencies:
-      '@types/jest': 28.1.8
       aws-sdk-client-mock: 3.0.1
+      expect: 29.7.0
       tslib: 2.6.2
     dev: true
 
@@ -3869,11 +3832,6 @@ packages:
   /detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
-
-  /diff-sequences@28.1.1:
-    resolution: {integrity: sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dev: true
 
   /diff-sequences@29.6.3:
@@ -4590,17 +4548,6 @@ packages:
   /exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
-    dev: true
-
-  /expect@28.1.3:
-    resolution: {integrity: sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@jest/expect-utils': 28.1.3
-      jest-get-type: 28.0.2
-      jest-matcher-utils: 28.1.3
-      jest-message-util: 28.1.3
-      jest-util: 28.1.3
     dev: true
 
   /expect@29.7.0:
@@ -5799,16 +5746,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-diff@28.1.3:
-    resolution: {integrity: sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      chalk: 4.1.2
-      diff-sequences: 28.1.1
-      jest-get-type: 28.0.2
-      pretty-format: 28.1.3
-    dev: true
-
   /jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5849,11 +5786,6 @@ packages:
       jest-util: 29.7.0
     dev: true
 
-  /jest-get-type@28.0.2:
-    resolution: {integrity: sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dev: true
-
   /jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5886,16 +5818,6 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /jest-matcher-utils@28.1.3:
-    resolution: {integrity: sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      chalk: 4.1.2
-      jest-diff: 28.1.3
-      jest-get-type: 28.0.2
-      pretty-format: 28.1.3
-    dev: true
-
   /jest-matcher-utils@29.7.0:
     resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5904,21 +5826,6 @@ packages:
       jest-diff: 29.7.0
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
-    dev: true
-
-  /jest-message-util@28.1.3:
-    resolution: {integrity: sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@babel/code-frame': 7.23.5
-      '@jest/types': 28.1.3
-      '@types/stack-utils': 2.0.3
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      micromatch: 4.0.5
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      stack-utils: 2.0.6
     dev: true
 
   /jest-message-util@29.7.0:
@@ -6072,18 +5979,6 @@ packages:
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /jest-util@28.1.3:
-    resolution: {integrity: sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@jest/types': 28.1.3
-      '@types/node': 20.10.6
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      graceful-fs: 4.2.11
-      picomatch: 2.3.1
     dev: true
 
   /jest-util@29.7.0:
@@ -7345,16 +7240,6 @@ packages:
     resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
-
-  /pretty-format@28.1.3:
-    resolution: {integrity: sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@jest/schemas': 28.1.3
-      ansi-regex: 5.0.1
-      ansi-styles: 5.2.0
-      react-is: 18.2.0
     dev: true
 
   /pretty-format@29.7.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/node':
         specifier: ^20.10.6
         version: 20.10.6
+      dotenv:
+        specifier: 16.3.1
+        version: 16.3.1
       skuba:
         specifier: 7.3.1
         version: 7.3.1(@babel/core@7.23.6)
@@ -26,6 +29,9 @@ importers:
 
   packages/infra:
     dependencies:
+      '@seek/logger':
+        specifier: ^6.2.0
+        version: 6.2.0
       '@types/aws-lambda':
         specifier: ^8.10.130
         version: 8.10.130
@@ -57,6 +63,9 @@ importers:
       aws-sdk-client-mock-jest:
         specifier: 3.0.1
         version: 3.0.1(aws-sdk-client-mock@3.0.1)
+      pino-pretty:
+        specifier: 10.3.1
+        version: 10.3.1
 
 packages:
 
@@ -1938,6 +1947,15 @@ packages:
       config-chain: 1.1.13
     dev: true
 
+  /@seek/logger@6.2.0:
+    resolution: {integrity: sha512-n6cxZ66kZJmCpgsHyKgLyVaaD9dWuwHUGCVpkZL2Yk9sH4WM/uN1wVhgRpEumm7NBMuifGAO/svS0ywsWnHqSw==}
+    engines: {node: '>=16.11', npm: '>=5.5.0'}
+    dependencies:
+      dtrim: 1.11.2
+      pino: 8.17.2
+      pino-std-serializers: 6.2.2
+    dev: false
+
   /@semantic-release/commit-analyzer@10.0.4(semantic-release@21.1.2):
     resolution: {integrity: sha512-pFGn99fn8w4/MHE0otb2A/l5kxgOuxaaauIh4u30ncoTJuqWj4hXTgEJ03REqjS+w1R2vPftSsO26WC61yOcpw==}
     engines: {node: '>=18'}
@@ -2857,6 +2875,12 @@ packages:
       through: 2.3.8
     dev: true
 
+  /abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+
   /acorn-jsx@5.3.2(acorn@8.11.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3120,6 +3144,10 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
@@ -3241,6 +3269,9 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
+  /base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   /before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
     dev: true
@@ -3317,6 +3348,12 @@ packages:
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
+
+  /buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
@@ -3529,6 +3566,10 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
+  /colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+    dev: true
+
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
@@ -3698,6 +3739,10 @@ packages:
 
   /dateformat@3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
+    dev: true
+
+  /dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
     dev: true
 
   /debug@3.2.7:
@@ -3883,6 +3928,10 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /dtrim@1.11.2:
+    resolution: {integrity: sha512-i6Q3s/KUEaybdjwIj2H5HdEUai/nhz/lfM4k1BqJj1T4nyNvuTmdfle7tIsVBkZayXiK8VlLMJYz1+ckQJqxrA==}
+    dev: false
+
   /duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
     dependencies:
@@ -3931,6 +3980,12 @@ packages:
       iconv-lite: 0.6.3
     dev: true
     optional: true
+
+  /end-of-stream@1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    dependencies:
+      once: 1.4.0
+    dev: true
 
   /enhanced-resolve@5.15.0:
     resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
@@ -4479,6 +4534,14 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  /events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -4551,6 +4614,10 @@ packages:
       jest-util: 29.7.0
     dev: true
 
+  /fast-copy@3.0.1:
+    resolution: {integrity: sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==}
+    dev: true
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -4572,6 +4639,15 @@ packages:
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    dev: true
+
+  /fast-redact@3.3.0:
+    resolution: {integrity: sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: true
 
   /fast-xml-parser@4.2.5:
@@ -5057,6 +5133,10 @@ packages:
       function-bind: 1.1.2
     dev: true
 
+  /help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+    dev: true
+
   /hook-std@3.0.0:
     resolution: {integrity: sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5131,6 +5211,9 @@ packages:
       safer-buffer: 2.1.2
     dev: true
     optional: true
+
+  /ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   /ignore@5.3.0:
     resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
@@ -6092,6 +6175,11 @@ packages:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
 
+  /joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+    dev: true
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: true
@@ -6903,6 +6991,10 @@ packages:
       es-abstract: 1.22.3
     dev: true
 
+  /on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
@@ -7164,6 +7256,53 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /pino-abstract-transport@1.1.0:
+    resolution: {integrity: sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==}
+    dependencies:
+      readable-stream: 4.5.2
+      split2: 4.2.0
+
+  /pino-pretty@10.3.1:
+    resolution: {integrity: sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==}
+    hasBin: true
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.1
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.1.0
+      pump: 3.0.0
+      readable-stream: 4.5.2
+      secure-json-parse: 2.7.0
+      sonic-boom: 3.7.0
+      strip-json-comments: 3.1.1
+    dev: true
+
+  /pino-std-serializers@6.2.2:
+    resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
+    dev: false
+
+  /pino@8.17.2:
+    resolution: {integrity: sha512-LA6qKgeDMLr2ux2y/YiUt47EfgQ+S9LznBWOJdN3q1dx2sv0ziDLUBeVpyVv17TEcGCBuWf0zNtg3M5m1NhhWQ==}
+    hasBin: true
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.3.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.1.0
+      pino-std-serializers: 6.2.2
+      process-warning: 3.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.4.3
+      sonic-boom: 3.7.0
+      thread-stream: 2.4.1
+    dev: false
+
   /pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
@@ -7236,6 +7375,14 @@ packages:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
     dev: true
 
+  /process-warning@3.0.0:
+    resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
+    dev: false
+
+  /process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   /promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
@@ -7264,6 +7411,13 @@ packages:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
     dev: true
 
+  /pump@3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
+    dev: true
+
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -7276,6 +7430,10 @@ packages:
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
+
+  /quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+    dev: false
 
   /quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
@@ -7359,12 +7517,27 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
+  /readable-stream@4.5.2:
+    resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
     dev: true
+
+  /real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+    dev: false
 
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7532,7 +7705,6 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: true
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -7542,11 +7714,20 @@ packages:
       is-regex: 1.1.4
     dev: true
 
+  /safe-stable-stringify@2.4.3:
+    resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
+    engines: {node: '>=10'}
+    dev: false
+
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     requiresBuild: true
     dev: true
     optional: true
+
+  /secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+    dev: true
 
   /semantic-release@21.1.2(typescript@5.2.2):
     resolution: {integrity: sha512-kz76azHrT8+VEkQjoCBHE06JNQgTgsC4bT8XfCzb7DHcsk9vG3fqeMVik8h5rcWCYi2Fd+M3bwA7BG8Z8cRwtA==}
@@ -7849,6 +8030,11 @@ packages:
       smart-buffer: 4.2.0
     dev: true
 
+  /sonic-boom@3.7.0:
+    resolution: {integrity: sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==}
+    dependencies:
+      atomic-sleep: 1.0.0
+
   /sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
     dev: true
@@ -7924,7 +8110,6 @@ packages:
   /split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-    dev: true
 
   /split@1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
@@ -8040,7 +8225,6 @@ packages:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -8199,6 +8383,12 @@ packages:
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
+
+  /thread-stream@2.4.1:
+    resolution: {integrity: sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==}
+    dependencies:
+      real-require: 0.2.0
+    dev: false
 
   /through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}


### PR DESCRIPTION
If our smoke test logic fails or takes too long, we need to send a "Failed" status back to CodeDeploy so it knows to roll back the deployment. Otherwise, the deployment will hang until it times out (after 1 hour by default).