### PR TITLE
Limit hook permissions by resource tag

### DIFF
--- a/packages/infra/src/constructs/__snapshots__/stack.test.ts.snap
+++ b/packages/infra/src/constructs/__snapshots__/stack.test.ts.snap
@@ -88,6 +88,29 @@ exports[`returns expected CloudFormation stack 1`] = `
               "Effect": "Allow",
               "Resource": "*",
             },
+            {
+              "Action": "*",
+              "Condition": {
+                "Null": {
+                  "aws:ResourceTag/aws-codedeploy-hooks": "true",
+                },
+              },
+              "Effect": "Deny",
+              "Resource": "*",
+            },
+            {
+              "Action": "*",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/aws-codedeploy-hooks": [
+                    "",
+                    "false",
+                  ],
+                },
+              },
+              "Effect": "Deny",
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/packages/infra/src/constructs/stack.ts
+++ b/packages/infra/src/constructs/stack.ts
@@ -35,6 +35,35 @@ export class HookStack extends Stack {
           'codedeploy:PutLifecycleEventHookExecutionStatus',
           'lambda:InvokeFunction',
         ],
+        effect: aws_iam.Effect.ALLOW,
+        resources: ['*'],
+      }),
+    );
+
+    // Deny access to resources that lack an `aws-codedeploy-hooks` tag.
+    beforeAllowTrafficHook.addToRolePolicy(
+      new aws_iam.PolicyStatement({
+        actions: ['*'],
+        conditions: {
+          Null: {
+            'aws:ResourceTag/aws-codedeploy-hooks': 'true',
+          },
+        },
+        effect: aws_iam.Effect.DENY,
+        resources: ['*'],
+      }),
+    );
+
+    // Deny access to resources that have a falsy `aws-codedeploy-hooks` tag.
+    beforeAllowTrafficHook.addToRolePolicy(
+      new aws_iam.PolicyStatement({
+        actions: ['*'],
+        conditions: {
+          StringEquals: {
+            'aws:ResourceTag/aws-codedeploy-hooks': ['', 'false'],
+          },
+        },
+        effect: aws_iam.Effect.DENY,
         resources: ['*'],
       }),
     );


### PR DESCRIPTION
I figured `aws-codedeploy-hooks` would be uncontroversial and unlikely to conflict with other usage.

Closes #14.