### PR TITLE
Precompile hooks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,3 +14,4 @@ node_modules*/
 # end managed by skuba
 
 /packages/**/lib*/
+/packages/infra/src/assets/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,11 @@ module.exports = {
         '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
       },
     },
+    {
+      files: ['packages/infra/cli/**'],
+      rules: {
+        'no-console': 'off',
+      },
+    },
   ],
 };

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Codegen
+        run: pnpm run codegen
+
       - name: Test
         run: pnpm run test:ci
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,7 @@ yarn-error.log
 
 /packages/**/lib*/
 
+/packages/infra/src/assets/
+/packages/infra/src/version.ts
+
 !.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -4,7 +4,3 @@ public-hoist-pattern[]=*eslint*
 public-hoist-pattern[]=*prettier*
 public-hoist-pattern[]=tsconfig-seek
 # end managed by skuba
-
-#  ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL : Command "esbuild" not found
-# https://github.com/aws/aws-cdk/issues/13179#issuecomment-1570171099
-public-hoist-pattern[]=esbuild

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,7 @@
 import { Jest } from 'skuba';
 
 export default Jest.mergePreset({
+  coveragePathIgnorePatterns: ['<rootDir>/packages/infra/cli/'],
   coverageThreshold: {
     global: {
       branches: 100,

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "pnpm --filter ./packages/hooks run build",
+    "build": "pnpm run --recursive build",
     "changeset": "changeset",
+    "codegen": "pnpm run --recursive codegen",
     "format": "skuba format",
     "lint": "skuba lint",
     "release": "pnpm run --silent build && changeset publish",
@@ -18,6 +19,7 @@
     "@changesets/get-github-info": "0.6.0",
     "@types/node": "^20.10.6",
     "dotenv": "16.3.1",
+    "esbuild": "~0.20.0",
     "skuba": "7.3.1"
   },
   "packageManager": "pnpm@8.14.0",

--- a/packages/infra/cli/codegen/bundleAssets.ts
+++ b/packages/infra/cli/codegen/bundleAssets.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+
+import esbuild from 'esbuild';
+
+import { rootdir } from './rootdir';
+
+const outdir = path.join(rootdir, 'src', 'assets');
+
+export const bundleAssets = async () => {
+  console.log(`Clearing ${path.relative(process.cwd(), outdir)}...`);
+
+  await fs.promises.rm(outdir, { force: true, recursive: true });
+
+  console.log(
+    `Bundling handlers into ${path.relative(process.cwd(), outdir)}...`,
+  );
+
+  await esbuild.build({
+    bundle: true,
+    charset: 'utf8',
+    entryPoints: [
+      {
+        in: path.join(rootdir, 'src', 'handlers', 'index.ts'),
+        out: 'handlers/index',
+      },
+    ],
+    external: [
+      // Rely on AWS SDK V3 built in to the Lambda runtime.
+      '@aws-sdk/*',
+    ],
+    format: 'esm',
+    logLevel: 'debug',
+    outdir,
+    platform: 'node',
+    sourcemap: true,
+    target: 'node20',
+  });
+};

--- a/packages/infra/cli/codegen/index.ts
+++ b/packages/infra/cli/codegen/index.ts
@@ -1,0 +1,32 @@
+import { bundleAssets } from './bundleAssets';
+import { writeVersion } from './writeVersion';
+
+const main = async () => {
+  console.log(
+    `
+===============
+Bundling assets
+===============
+`.trimEnd(),
+  );
+
+  await bundleAssets();
+
+  console.log('Complete.');
+
+  console.log(
+    `
+===============
+Writing version
+===============
+`.trimEnd(),
+  );
+
+  await writeVersion();
+
+  console.log('Complete.');
+};
+
+main().catch((err) => {
+  throw err;
+});

--- a/packages/infra/cli/codegen/rootdir.ts
+++ b/packages/infra/cli/codegen/rootdir.ts
@@ -1,0 +1,3 @@
+import path from 'path';
+
+export const rootdir = path.join(__dirname, '..', '..');

--- a/packages/infra/cli/codegen/writeVersion.ts
+++ b/packages/infra/cli/codegen/writeVersion.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+import { rootdir } from './rootdir';
+
+export const writeVersion = async () => {
+  const { version } = await import('../../package.json');
+
+  if (!version) {
+    throw new Error('No version found in package.json');
+  }
+
+  const filepath = path.join(rootdir, 'src', 'version.ts');
+
+  console.log(
+    `Writing ${version} to ${path.relative(process.cwd(), filepath)}...`,
+  );
+
+  await fs.promises.writeFile(
+    filepath,
+    `export const version = '${version}';\n`,
+  );
+};

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@seek/aws-codedeploy-infra",
+  "version": "0.0.0",
   "private": true,
   "license": "MIT",
   "files": [],
+  "scripts": {
+    "build": "pnpm run --silent codegen && skuba build",
+    "codegen": "skuba node cli/codegen"
+  },
   "dependencies": {
     "@seek/logger": "^6.2.0",
     "@types/aws-lambda": "^8.10.130",
@@ -17,5 +22,11 @@
     "aws-sdk-client-mock": "3.1.0-beta.0",
     "aws-sdk-client-mock-jest": "3.1.0-beta.0",
     "pino-pretty": "10.3.1"
+  },
+  "skuba": {
+    "assets": [
+      "assets/**/*"
+    ],
+    "build": "esbuild"
   }
 }

--- a/packages/infra/src/constructs/lambda.ts
+++ b/packages/infra/src/constructs/lambda.ts
@@ -1,25 +1,11 @@
 import path from 'path';
 
-import { Duration } from 'aws-cdk-lib';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
-import * as nodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Duration, aws_lambda } from 'aws-cdk-lib';
 
-export const LAMBDA_HOOK_PROPS: nodejs.NodejsFunctionProps = {
-  // Rely on AWS SDK V3 default behaviour of connection reuse.
-  awsSdkConnectionReuse: false,
-
-  bundling: {
-    externalModules: [
-      // Rely on AWS SDK V3 built in to the Lambda runtime.
-      '@aws-sdk/*',
-    ],
-    charset: nodejs.Charset.UTF8,
-    format: nodejs.OutputFormat.ESM,
-    sourceMap: true,
-    target: 'node20',
-  },
-
-  entry: path.join(__dirname, '..', 'handlers', 'index.ts'),
+export const LAMBDA_HOOK_PROPS: aws_lambda.FunctionProps = {
+  code: aws_lambda.Code.fromAsset(
+    path.join(__dirname, '..', 'assets', 'handlers'),
+  ),
 
   environment: {
     NODE_ENV: 'production',
@@ -28,7 +14,9 @@ export const LAMBDA_HOOK_PROPS: nodejs.NodejsFunctionProps = {
     NODE_OPTIONS: '--enable-source-maps',
   },
 
-  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: 'index.handler',
+
+  runtime: aws_lambda.Runtime.NODEJS_20_X,
 
   timeout: Duration.seconds(300),
 };

--- a/packages/infra/src/constructs/stack.test.ts
+++ b/packages/infra/src/constructs/stack.test.ts
@@ -1,5 +1,4 @@
-import { App } from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { App, assertions } from 'aws-cdk-lib';
 
 import { HookStack } from './stack';
 
@@ -8,7 +7,7 @@ it('returns expected CloudFormation stack', () => {
 
   const stack = new HookStack(app);
 
-  const template = Template.fromStack(stack);
+  const template = assertions.Template.fromStack(stack);
 
   template.resourceCountIs('AWS::Lambda::Function', 1);
 

--- a/packages/infra/src/constructs/stack.ts
+++ b/packages/infra/src/constructs/stack.ts
@@ -1,5 +1,4 @@
-import { Stack, aws_iam } from 'aws-cdk-lib';
-import * as nodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Stack, aws_iam, aws_lambda } from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
 
 import { LAMBDA_HOOK_PROPS } from './lambda';
@@ -16,7 +15,7 @@ export class HookStack extends Stack {
       terminationProtection: true,
     });
 
-    const beforeAllowTrafficHook = new nodejs.NodejsFunction(
+    const beforeAllowTrafficHook = new aws_lambda.Function(
       this,
       'BeforeAllowTrafficHook',
       {

--- a/packages/infra/src/version.test.ts
+++ b/packages/infra/src/version.test.ts
@@ -1,0 +1,6 @@
+import { version } from './version';
+
+it('is a truthy string', () => {
+  expect(typeof version).toBe('string');
+  expect(version).toBeTruthy();
+});

--- a/packages/infra/tsconfig.build.json
+++ b/packages/infra/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "removeComments": false,
+    "rootDir": "src"
+  },
+  "exclude": [
+    "**/__mocks__/**/*",
+    "**/*.test.ts",
+    "src/handlers/**/*",
+    "src/testing/**/*"
+  ],
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       dotenv:
         specifier: 16.3.1
         version: 16.3.1
+      esbuild:
+        specifier: ~0.20.0
+        version: 0.20.0
       skuba:
         specifier: 7.3.1
         version: 7.3.1(@babel/core@7.23.6)
@@ -1297,8 +1300,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.20.0:
+    resolution: {integrity: sha512-fGFDEctNh0CcSwsiRPxiaqX0P5rq+AqE0SRhYGZ4PX46Lg1FNR6oCxJghf8YgY0WQEgQuh3lErUFE4KxLeRmmw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.19.10:
     resolution: {integrity: sha512-1X4CClKhDgC3by7k8aOWZeBXQX8dHT5QAMCAQDArCLaYfkppoARvh0fit3X2Qs+MXDngKcHv6XXyQCpY0hkK1Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.20.0:
+    resolution: {integrity: sha512-aVpnM4lURNkp0D3qPoAzSG92VXStYmoVPOgXveAUoQBWRSuQzt51yvSju29J6AHPmwY1BjH49uR29oyfH1ra8Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1315,8 +1336,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.20.0:
+    resolution: {integrity: sha512-3bMAfInvByLHfJwYPJRlpTeaQA75n8C/QKpEaiS4HrFWFiJlNI0vzq/zCjBrhAYcPyVPG7Eo9dMrcQXuqmNk5g==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.19.10:
     resolution: {integrity: sha512-O/nO/g+/7NlitUxETkUv/IvADKuZXyH4BHf/g/7laqKC4i/7whLpB0gvpPc2zpF0q9Q6FXS3TS75QHac9MvVWw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.20.0:
+    resolution: {integrity: sha512-uK7wAnlRvjkCPzh8jJ+QejFyrP8ObKuR5cBIsQZ+qbMunwR8sbd8krmMbxTLSrDhiPZaJYKQAU5Y3iMDcZPhyQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -1333,8 +1372,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.20.0:
+    resolution: {integrity: sha512-AjEcivGAlPs3UAcJedMa9qYg9eSfU6FnGHJjT8s346HSKkrcWlYezGE8VaO2xKfvvlZkgAhyvl06OJOxiMgOYQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.19.10:
     resolution: {integrity: sha512-alfGtT+IEICKtNE54hbvPg13xGBe4GkVxyGWtzr+yHO7HIiRJppPDhOKq3zstTcVf8msXb/t4eavW3jCDpMSmA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.20.0:
+    resolution: {integrity: sha512-bsgTPoyYDnPv8ER0HqnJggXK6RyFy4PH4rtsId0V7Efa90u2+EifxytE9pZnsDgExgkARy24WUQGv9irVbTvIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -1351,8 +1408,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.20.0:
+    resolution: {integrity: sha512-kQ7jYdlKS335mpGbMW5tEe3IrQFIok9r84EM3PXB8qBFJPSc6dpWfrtsC/y1pyrz82xfUIn5ZrnSHQQsd6jebQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.19.10:
     resolution: {integrity: sha512-G5UPPspryHu1T3uX8WiOEUa6q6OlQh6gNl4CO4Iw5PS+Kg5bVggVFehzXBJY6X6RSOMS8iXDv2330VzaObm4Ag==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.20.0:
+    resolution: {integrity: sha512-uG8B0WSepMRsBNVXAQcHf9+Ko/Tr+XqmK7Ptel9HVmnykupXdS4J7ovSQUIi0tQGIndhbqWLaIL/qO/cWhXKyQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -1369,8 +1444,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.20.0:
+    resolution: {integrity: sha512-uTtyYAP5veqi2z9b6Gr0NUoNv9F/rOzI8tOD5jKcCvRUn7T60Bb+42NDBCWNhMjkQzI0qqwXkQGo1SY41G52nw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.19.10:
     resolution: {integrity: sha512-j6gUW5aAaPgD416Hk9FHxn27On28H4eVI9rJ4az7oCGTFW48+LcgNDBN+9f8rKZz7EEowo889CPKyeaD0iw9Kg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.20.0:
+    resolution: {integrity: sha512-2ezuhdiZw8vuHf1HKSf4TIk80naTbP9At7sOqZmdVwvvMyuoDiZB49YZKLsLOfKIr77+I40dWpHVeY5JHpIEIg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -1387,8 +1480,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.20.0:
+    resolution: {integrity: sha512-c88wwtfs8tTffPaoJ+SQn3y+lKtgTzyjkD8NgsyCtCmtoIC8RDL7PrJU05an/e9VuAke6eJqGkoMhJK1RY6z4w==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.19.10:
     resolution: {integrity: sha512-lo3I9k+mbEKoxtoIbM0yC/MZ1i2wM0cIeOejlVdZ3D86LAcFXFRdeuZmh91QJvUTW51bOK5W2BznGNIl4+mDaA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.20.0:
+    resolution: {integrity: sha512-lR2rr/128/6svngnVta6JN4gxSXle/yZEZL3o4XZ6esOqhyR4wsKyfu6qXAL04S4S5CgGfG+GYZnjFd4YiG3Aw==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -1405,8 +1516,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.20.0:
+    resolution: {integrity: sha512-9Sycc+1uUsDnJCelDf6ZNqgZQoK1mJvFtqf2MUz4ujTxGhvCWw+4chYfDLPepMEvVL9PDwn6HrXad5yOrNzIsQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.19.10:
     resolution: {integrity: sha512-tgT/7u+QhV6ge8wFMzaklOY7KqiyitgT1AUHMApau32ZlvTB/+efeCtMk4eXS+uEymYK249JsoiklZN64xt6oQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.20.0:
+    resolution: {integrity: sha512-CoWSaaAXOZd+CjbUTdXIJE/t7Oz+4g90A3VBCHLbfuc5yUQU/nFDLOzQsN0cdxgXd97lYW/psIIBdjzQIwTBGw==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1423,8 +1552,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.20.0:
+    resolution: {integrity: sha512-mlb1hg/eYRJUpv8h/x+4ShgoNLL8wgZ64SUr26KwglTYnwAWjkhR2GpoKftDbPOCnodA9t4Y/b68H4J9XmmPzA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.19.10:
     resolution: {integrity: sha512-pZFe0OeskMHzHa9U38g+z8Yx5FNCLFtUnJtQMpwhS+r4S566aK2ci3t4NCP4tjt6d5j5uo4h7tExZMjeKoehAA==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.20.0:
+    resolution: {integrity: sha512-fgf9ubb53xSnOBqyvWEY6ukBNRl1mVX1srPNu06B6mNsNK20JfH6xV6jECzrQ69/VMiTLvHMicQR/PgTOgqJUQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -1441,8 +1588,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.20.0:
+    resolution: {integrity: sha512-H9Eu6MGse++204XZcYsse1yFHmRXEWgadk2N58O/xd50P9EvFMLJTQLg+lB4E1cF2xhLZU5luSWtGTb0l9UeSg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.19.10:
     resolution: {integrity: sha512-ACbZ0vXy9zksNArWlk2c38NdKg25+L9pr/mVaj9SUq6lHZu/35nx2xnQVRGLrC1KKQqJKRIB0q8GspiHI3J80Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.20.0:
+    resolution: {integrity: sha512-lCT675rTN1v8Fo+RGrE5KjSnfY0x9Og4RN7t7lVrN3vMSjy34/+3na0q7RIfWDAj0e0rCh0OL+P88lu3Rt21MQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -1459,8 +1624,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.20.0:
+    resolution: {integrity: sha512-HKoUGXz/TOVXKQ+67NhxyHv+aDSZf44QpWLa3I1lLvAwGq8x1k0T+e2HHSRvxWhfJrFxaaqre1+YyzQ99KixoA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.19.10:
     resolution: {integrity: sha512-ZkIOtrRL8SEJjr+VHjmW0znkPs+oJXhlJbNwfI37rvgeMtk3sxOQevXPXjmAPZPigVTncvFqLMd+uV0IBSEzqA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.20.0:
+    resolution: {integrity: sha512-GDwAqgHQm1mVoPppGsoq4WJwT3vhnz/2N62CzhvApFD1eJyTroob30FPpOZabN+FgCjhG+AgcZyOPIkR8dfD7g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -1477,6 +1660,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64@0.20.0:
+    resolution: {integrity: sha512-0vYsP8aC4TvMlOQYozoksiaxjlvUcQrac+muDqj1Fxy6jh9l9CZJzj7zmh8JGfiV49cYLTorFLxg7593pGldwQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32@0.19.10:
     resolution: {integrity: sha512-EOGVLK1oWMBXgfttJdPHDTiivYSjX6jDNaATeNOaCOFEVcfMjtbx7WVQwPSE1eIfCp/CaSF2nSrDtzc4I9f8TQ==}
     engines: {node: '>=12'}
@@ -1486,8 +1678,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.20.0:
+    resolution: {integrity: sha512-p98u4rIgfh4gdpV00IqknBD5pC84LCub+4a3MO+zjqvU5MVXOc3hqR2UgT2jI2nh3h8s9EQxmOsVI3tyzv1iFg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.19.10:
     resolution: {integrity: sha512-whqLG6Sc70AbU73fFYvuYzaE4MNMBIlR1Y/IrUeOXFrWHxBEjjbZaQ3IXIQS8wJdAzue2GwYZCjOrgrU1oUHoA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.20.0:
+    resolution: {integrity: sha512-NgJnesu1RtWihtTtXGFMU5YSE6JyyHPMxCwBZK7a6/8d31GuSo9l0Ss7w1Jw5QnKUawG6UEehs883kcXf5fYwg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -4335,6 +4545,37 @@ packages:
       '@esbuild/win32-arm64': 0.19.10
       '@esbuild/win32-ia32': 0.19.10
       '@esbuild/win32-x64': 0.19.10
+    dev: true
+
+  /esbuild@0.20.0:
+    resolution: {integrity: sha512-6iwE3Y2RVYCME1jLpBqq7LQWK3MW6vjV2bZy6gt/WrqkY+WE74Spyc0ThAOYpMtITvnjX09CrC6ym7A/m9mebA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.20.0
+      '@esbuild/android-arm': 0.20.0
+      '@esbuild/android-arm64': 0.20.0
+      '@esbuild/android-x64': 0.20.0
+      '@esbuild/darwin-arm64': 0.20.0
+      '@esbuild/darwin-x64': 0.20.0
+      '@esbuild/freebsd-arm64': 0.20.0
+      '@esbuild/freebsd-x64': 0.20.0
+      '@esbuild/linux-arm': 0.20.0
+      '@esbuild/linux-arm64': 0.20.0
+      '@esbuild/linux-ia32': 0.20.0
+      '@esbuild/linux-loong64': 0.20.0
+      '@esbuild/linux-mips64el': 0.20.0
+      '@esbuild/linux-ppc64': 0.20.0
+      '@esbuild/linux-riscv64': 0.20.0
+      '@esbuild/linux-s390x': 0.20.0
+      '@esbuild/linux-x64': 0.20.0
+      '@esbuild/netbsd-x64': 0.20.0
+      '@esbuild/openbsd-x64': 0.20.0
+      '@esbuild/sunos-x64': 0.20.0
+      '@esbuild/win32-arm64': 0.20.0
+      '@esbuild/win32-ia32': 0.20.0
+      '@esbuild/win32-x64': 0.20.0
     dev: true
 
   /escalade@3.1.1:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,11 @@
     "target": "ES2022"
   },
   "exclude": ["lib*/**/*"],
-  "extends": "skuba/config/tsconfig.json"
+  "extends": "skuba/config/tsconfig.json",
+  "include": [
+    "jest.config.ts",
+    "jest.setup.ts",
+    "packages/**/*",
+    "packages/**/package.json"
+  ]
 }


### PR DESCRIPTION
So package consumers don't need to have a compatible `esbuild` version installed and hoisted whenever they are deploying the hook infra stack.

Closes #10.