### PR TITLE
HookStack: Allow multiple instances

### DIFF
--- a/.changeset/plenty-steaks-flow.md
+++ b/.changeset/plenty-steaks-flow.md
@@ -1,0 +1,5 @@
+---
+'@seek/aws-codedeploy-infra': patch
+---
+
+HookStack: Allow multiple instances

--- a/packages/infra/src/constructs/lambda.ts
+++ b/packages/infra/src/constructs/lambda.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { Duration, aws_lambda } from 'aws-cdk-lib';
 
-export const LAMBDA_HOOK_PROPS: aws_lambda.FunctionProps = {
+export const createLambdaHookProps = (): aws_lambda.FunctionProps => ({
   code: aws_lambda.Code.fromAsset(
     path.join(__dirname, '..', 'assets', 'handlers'),
   ),
@@ -19,4 +19,4 @@ export const LAMBDA_HOOK_PROPS: aws_lambda.FunctionProps = {
   runtime: aws_lambda.Runtime.NODEJS_20_X,
 
   timeout: Duration.seconds(300),
-};
+});

--- a/packages/infra/src/constructs/stack.test.ts
+++ b/packages/infra/src/constructs/stack.test.ts
@@ -24,3 +24,13 @@ it('returns expected CloudFormation stack', () => {
 
   expect(JSON.parse(json)).toMatchSnapshot();
 });
+
+it('supports a custom ID', () => {
+  const app = new App();
+
+  const stack = new HookStack(app, 'MyStack');
+
+  const template = assertions.Template.fromStack(stack);
+
+  template.resourceCountIs('AWS::Lambda::Function', 1);
+});

--- a/packages/infra/src/constructs/stack.ts
+++ b/packages/infra/src/constructs/stack.ts
@@ -1,7 +1,7 @@
 import { Stack, aws_iam, aws_lambda } from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
 
-import { LAMBDA_HOOK_PROPS } from './lambda';
+import { createLambdaHookProps } from './lambda';
 
 export type HookStackProps = Record<string, never>;
 
@@ -17,7 +17,7 @@ export class HookStack extends Stack {
       this,
       'BeforeAllowTrafficHook',
       {
-        ...LAMBDA_HOOK_PROPS,
+        ...createLambdaHookProps(),
         description: 'BeforeAllowTraffic hook deployed outside of a VPC',
         functionName: 'aws-codedeploy-hook-BeforeAllowTraffic',
         vpc: undefined,


### PR DESCRIPTION
Just some internal cleanup to support multiple `HookStack` tests without running into this error:

```shell
Asset is already associated with another stack 'aws-codedeploy-hooks'. Create a new Code instance for every stack.
```