### PR TITLE
Use fork code path for Dependabot

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,19 +15,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: >-
-          github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.actor != 'dependabot[bot]' && (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
         name: Check out repo
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
 
       - if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository
+          github.actor == 'dependabot[bot]' || (
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name != github.repository
+          )
         name: Check out repo
         uses: actions/checkout@v4
-        # We don't share secrets with forks.
+        # We don't share secrets with Dependabot nor forks.
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
CI is broken on #35 because Dependabot-initiated workflows do not have access to GitHub Actions secrets:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events