### PR TITLE
HookStack: Increase AWS SDK retries

### DIFF
--- a/.changeset/cold-adults-ring.md
+++ b/.changeset/cold-adults-ring.md
@@ -1,0 +1,5 @@
+---
+'@seek/aws-codedeploy-infra': patch
+---
+
+HookStack: Increase AWS SDK retries

--- a/packages/infra/src/handlers/framework/aws.ts
+++ b/packages/infra/src/handlers/framework/aws.ts
@@ -1,12 +1,15 @@
-import { CodeDeployClient } from '@aws-sdk/client-codedeploy';
-import { LambdaClient } from '@aws-sdk/client-lambda';
+import {
+  CodeDeployClient,
+  type CodeDeployClientConfig,
+} from '@aws-sdk/client-codedeploy';
+import { LambdaClient, type LambdaClientConfig } from '@aws-sdk/client-lambda';
 
 import { config } from '../config';
 
 const clientConfig = {
-  maxAttempts: 5,
+  maxAttempts: 8,
   region: config.region,
-};
+} satisfies CodeDeployClientConfig & LambdaClientConfig;
 
 export const codeDeployClient = new CodeDeployClient(clientConfig);
 


### PR DESCRIPTION
I was initially looking at the adaptive strategy or a custom backoff function, but I think this should be fine to begin with. The hook has logic to try to short circuit if this all takes too long.

- https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html
- https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-util-retry/
- https://github.com/seek-oss/aws-codedeploy-hooks/blob/714756b69539717fd25f4420c893f29f9b7fc317/packages/infra/src/handlers/index.ts#L20