### PR TITLE
feat: extend `HookStackProps` from `StackProps`

### DIFF
--- a/.changeset/tired-islands-matter.md
+++ b/.changeset/tired-islands-matter.md
@@ -1,0 +1,5 @@
+---
+'@seek/aws-codedeploy-infra': minor
+---
+
+HookStack: extend `HookStackProps` from `StackProps`

--- a/packages/infra/src/constructs/stack.test.ts
+++ b/packages/infra/src/constructs/stack.test.ts
@@ -34,3 +34,27 @@ it('supports a custom ID', () => {
 
   template.resourceCountIs('AWS::Lambda::Function', 2);
 });
+
+describe('StackProps', () => {
+  it('should use default values when none are provided', () => {
+    const app = new App();
+
+    const defaultStack = new HookStack(app);
+    expect(defaultStack.stackName).toBe('aws-codedeploy-hooks');
+    expect(defaultStack.tags.hasTags()).toBeFalsy();
+  });
+
+  it('should override the defaults when provided', () => {
+    const app = new App();
+
+    const customStack = new HookStack(app, 'CustomStack', {
+      stackName: 'custom',
+      tags: { 'seek:custom:tag': 'value' },
+    });
+    expect(customStack.stackName).toBe('custom');
+    expect(customStack.tags.hasTags()).toBeTruthy();
+    expect(customStack.tags.tagValues()).toEqual({
+      'seek:custom:tag': 'value',
+    });
+  });
+});

--- a/packages/infra/src/constructs/stack.ts
+++ b/packages/infra/src/constructs/stack.ts
@@ -1,22 +1,27 @@
-import { Stack, aws_iam, aws_lambda } from 'aws-cdk-lib';
+import { Stack, type StackProps, aws_iam, aws_lambda } from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
 
 import { createLambdaHookProps } from './lambda';
 
 type HookName = 'BeforeAllowTraffic' | 'AfterAllowTraffic';
 
-export type HookStackProps = {
+export type HookStackProps = StackProps & {
   prune?: {
     versionsToKeep?: number;
   };
 };
 
+const defaultProps: HookStackProps = {
+  description: 'AWS CodeDeploy hooks',
+  stackName: 'aws-codedeploy-hooks',
+  terminationProtection: true,
+};
+
 export class HookStack extends Stack {
   constructor(scope: Construct, id?: string, props: HookStackProps = {}) {
     super(scope, id ?? 'HookStack', {
-      description: 'AWS CodeDeploy hooks',
-      stackName: 'aws-codedeploy-hooks',
-      terminationProtection: true,
+      ...defaultProps,
+      ...props,
     });
 
     this.addHook('BeforeAllowTraffic', {}, ['lambda:InvokeFunction']);


### PR DESCRIPTION
This allows the common "stack props" to be used during creation of this stack, as well as our custom `prune` value.

Some potential talking points:

1. Previously we were forcing the `description`, `stackName` and `terminationProtection` values, now consumers can override these values. Do we want/need to maintain that enforcement?